### PR TITLE
Remove unused typing imports

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,7 +2,6 @@ from fastmcp import FastMCP
 import httpx
 import json
 import asyncio
-from typing import Optional, Dict, Any, List
 import os
 
 # Get port from environment or use default 9001


### PR DESCRIPTION
## Summary
- delete `Optional`, `Dict`, `Any`, and `List` from `server.py`

## Testing
- `python -m py_compile server.py client.py`


------
https://chatgpt.com/codex/tasks/task_e_6840eebdd28c8332b6acc6612e8a0a04